### PR TITLE
update akai api retry process

### DIFF
--- a/api/basics_test.go
+++ b/api/basics_test.go
@@ -123,7 +123,7 @@ func basicServiceAndClient(t *testing.T, ctx context.Context) (*Service, *Client
 
 	// create and init the API client
 	cliCfg := DefaultClientConfig
-	cli, err := NewClient(cliCfg)
+	cli, err := NewClient(ctx, cliCfg)
 	require.NoError(t, err)
 	return ser, cli
 }

--- a/avail/block_consumer.go
+++ b/avail/block_consumer.go
@@ -83,16 +83,16 @@ type AkaiAPIconsumer struct {
 
 var _ BlockConsumer = (*AkaiAPIconsumer)(nil)
 
-func NewAkaiAPIconsumer(networkConfig *config.NetworkConfiguration, cfg *config.AkaiAPIClientConfig) (*AkaiAPIconsumer, error) {
-	apiCli, err := akai_api.NewClient(cfg)
+func NewAkaiAPIconsumer(ctx context.Context, networkConfig *config.NetworkConfiguration, cfg *config.AkaiAPIClientConfig) (*AkaiAPIconsumer, error) {
+	apiCli, err := akai_api.NewClient(ctx, cfg)
 	if err != nil {
 		return nil, err
 	}
 
 	// ensure that the network is the same one
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	opCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
-	apiNet, err := apiCli.GetSupportedNetworks(ctx)
+	apiNet, err := apiCli.GetSupportedNetworks(opCtx)
 	if err != nil {
 		return nil, err
 	}

--- a/avail/block_requester.go
+++ b/avail/block_requester.go
@@ -11,7 +11,7 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-var availAPIretries = 3
+var availAPIretries = 5
 
 type BlockRequester struct {
 	httpAPICli *api.HTTPClient
@@ -49,7 +49,7 @@ func (r *BlockRequester) AvailAPIhealthcheck(ctx context.Context) error {
 			log.Info("got successfull connection to avail-light-api")
 			return nil
 		}
-		time.Sleep(10 * time.Second) // retry again in 10 secs?
+		time.Sleep(30 * time.Second)
 	}
 	return fmt.Errorf("no connection available to avail-light-api")
 }

--- a/avail/block_tracker.go
+++ b/avail/block_tracker.go
@@ -26,7 +26,7 @@ type BlockTracker struct {
 	lastBlockGau     metric.Int64ObservableGauge
 }
 
-func NewBlockTracker(cfg *config.AvailBlockTracker) (*BlockTracker, error) {
+func NewBlockTracker(ctx context.Context, cfg *config.AvailBlockTracker) (*BlockTracker, error) {
 	// api
 	httpAPICli, err := api.NewHTTPCli(cfg.AvailAPIconfig)
 	if err != nil {
@@ -49,7 +49,7 @@ func NewBlockTracker(cfg *config.AvailBlockTracker) (*BlockTracker, error) {
 		blockConsumers = append(blockConsumers, textConsumer)
 	}
 	if cfg.AkaiAPIconsumer {
-		akaiAPIconsumer, err := NewAkaiAPIconsumer(networkConfig, cfg.AkaiAPIconfig)
+		akaiAPIconsumer, err := NewAkaiAPIconsumer(ctx, networkConfig, cfg.AkaiAPIconfig)
 		if err != nil {
 			return nil, err
 		}

--- a/cmd/akai/cmd_avail_block_tracker.go
+++ b/cmd/akai/cmd_avail_block_tracker.go
@@ -145,7 +145,7 @@ func cmdAvailBlockTrackerAction(ctx context.Context, cmd *cli.Command) error {
 		Meter:           otel.GetMeterProvider().Meter("akai_avail_block_tracker"),
 	}
 
-	blockTracker, err := avail.NewBlockTracker(blockTrackerConfig)
+	blockTracker, err := avail.NewBlockTracker(ctx, blockTrackerConfig)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
# Description
Missing error on the retry + a context that wasn't being updated with a new timeout caused the Akai API retries to be useless.