### PR TITLE
Fix ctx bug on clickhouse query to retrieve sampleable blobs

### DIFF
--- a/db/clickhouse/segments.go
+++ b/db/clickhouse/segments.go
@@ -63,15 +63,10 @@ func requestSegmentWithCondition(ctx context.Context, highLevelConn driver.Conn,
 	query := fmt.Sprintf(`
 		SELECT 
 			timestamp,
-			blob_number,
 			key,
-			row,
-			column,
 			sample_until,
 		FROM %s
-		%s
-		ORDER BY blob_number, row, column;
-		`,
+		%s;`,
 		segmentTableDriver.tableName,
 		condition,
 	)


### PR DESCRIPTION
# Description
There was an error with the queries that would sync the sampler's segment set with the Clickhouse DB:
- The query was using the main `ctx` (big error on my end to miss that)
- The query was redundant (fetching and sorting things that are not needed)

This PR address those problems, making the step safer and faster.