### PR TITLE
fix(just): remove unused var and fix default

### DIFF
--- a/justfile
+++ b/justfile
@@ -7,10 +7,10 @@ GIT_PACKAGE := "github.com/probe-lab/akai"
 COMMIT := `git rev-parse --short HEAD`
 DATE := `date "+%Y-%m-%dT%H:%M:%SZ"`
 USER := `id -un`
-VERSION := `git describe --tags --abbrev=0 || true`
 
 default:
-	@just --list --jusfile {{justfile()}}
+  @just --list --justfile {{ justfile() }}
+
 
 install:
 	{{GOCC}} install {GIT_PACKAGE}


### PR DESCRIPTION
- We don't use tags in this repo (at least, I don't see it on remote)
- The `VERSION` variable is unused.
- Fixes a typo in the `default` directive that causes the exception described in #27 

closes: #27 